### PR TITLE
Fix PDF.js language display issue by adding locale parameter

### DIFF
--- a/app/views/pages/show.rb
+++ b/app/views/pages/show.rb
@@ -210,7 +210,7 @@ class Views::Pages::Show < Views::Base
       }
     ) do
       iframe(
-        src: pdfjs_path(file: @file.pdf_url, anchor: "page=#{@page.number}"),
+        src: pdfjs_path(file: @file.pdf_url, locale: I18n.locale, anchor: "page=#{@page.number}"),
         class: "w-full h-full",
         data: {
           pdf_viewer_target: "iframe",


### PR DESCRIPTION
- Add I18n.locale parameter to pdfjs_path helper call in pages/show.rb
- PDF viewer will now respect user's selected language (Arabic/English/Urdu)
- Fixes issue where PDF viewer always displayed in Arabic regardless of selection

Fixes #106