### PR TITLE
ci: enahce pipeline 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,17 @@ on:
     paths-ignore:
       - '**/*.md'
       - '.github/**'
+      - '.stimulus-lsp'
+      - '.kamal/**'
+      - '.vscode/**'
   push:
     branches: [ main ]
     paths-ignore:
       - '**/*.md'
       - '.github/**'
+      - '.stimulus-lsp'
+      - '.kamal/**'
+      - '.vscode/**'
 
 jobs:
   scan_ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
 
   active_record_doctor:
     runs-on: ubuntu-latest
+    needs: [scan_ruby, i18n-tasks, lint]
 
     services:
       postgres:
@@ -102,6 +103,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: [scan_ruby, i18n-tasks, lint]
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
 
 jobs:
   scan_ruby:


### PR DESCRIPTION
make simple checks run first, then run heavy tasks so we most probably save time, as if PR has lint issue he will fix and push again so we saved this time, so we run tasks when we are sure that code is fine. 